### PR TITLE
Fix a bug where column names do not match when overwriting an excel

### DIFF
--- a/src/fosslight_scanner/common.py
+++ b/src/fosslight_scanner/common.py
@@ -136,9 +136,13 @@ def overwrite_excel(excel_file_path, oss_name, column_name='OSS Name'):
                     excel_file = pd.ExcelFile(file, engine='openpyxl')
 
                     for sheet_name in excel_file.sheet_names:
-                        df = pd.read_excel(file, sheet_name=sheet_name, engine='openpyxl')
-                        updated = (df[column_name] == '') | (df[column_name].isnull())
-                        df.loc[updated, column_name] = oss_name
-                        df.to_excel(file, sheet_name=sheet_name, index=False)
+                        try:
+                            df = pd.read_excel(file, sheet_name=sheet_name, engine='openpyxl')
+                            if column_name in df.columns:
+                                updated = (df[column_name] == '') | (df[column_name].isnull())
+                                df.loc[updated, column_name] = oss_name
+                                df.to_excel(file, sheet_name=sheet_name, index=False)
+                        except Exception as ex:
+                            logger.debug(f"overwrite_sheet {sheet_name}:{ex}")
         except Exception as ex:
             logger.debug(f"overwrite_excel:{ex}")


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
When analyzed as a link, Excel overwrites the output result to enter the OSS Name and Download location. At this time, when the column name you are looking for is not found, handle an exception so that a bug does not occur.

## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

