### PR TITLE
Fix errors that occur when downloading link

### DIFF
--- a/src/fosslight_scanner/fosslight_scanner.py
+++ b/src/fosslight_scanner/fosslight_scanner.py
@@ -194,6 +194,7 @@ def download_source(link, out_dir):
         temp_src_dir = os.path.join(
             _output_dir, SRC_DIR_FROM_LINK_PREFIX + start_time)
 
+        link = link.strip()
         logger.info(f"Link to download: {link}")
         success, msg = cli_download_and_extract(
             link, temp_src_dir, _output_dir)


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
If there is space in the link, fix the error that occurs during download.
- error message : `git clone - failed:malformed URL 'https://github.com/LGE-OSS/example '`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

