### PR TITLE
Fix a bug where part of the output file is not created without the -o option

### DIFF
--- a/src/fosslight_scanner/common.py
+++ b/src/fosslight_scanner/common.py
@@ -15,10 +15,18 @@ logger = logging.getLogger(constant.LOGGER_NAME)
 
 
 def copy_file(source, destination):
+    copied_file = ""
     try:
         copy(source, destination)
+        if os.path.isdir(destination):
+            copied_file = os.path.join(destination, os.path.basename(source))
+        else:
+            copied_file = destination
     except Exception as ex:
         logger.debug(f"Failed to copy {source} to {destination}: {ex}")
+        return False, copied_file
+    else:
+        return True, copied_file
 
 
 def run_analysis(path_to_run, params, func, str_run_start, output, exe_path):


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix a bug where part of the output file is not created without the -o option.
- Bug that Reuse.xml and FL_Binary.txt are not created without -o option.
- Bug that Reuse.xml and FL_Binary.txt are not printed to the output file list even though they are created

## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

