### PR TITLE
Change the required version of Python to 3.7

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ FOSSLight Scanner needs a Python 3.6+.
 ## 🎉 How to install
 
 
-It can be installed using pip3. It is recommended to install it in the [python 3.6 + virtualenv]([etc/guide_virtualenv.md](https://fosslight.org/fosslight-guide-en/scanner/etc/guide_virtualenv.html)) environment.
+It can be installed using pip3. It is recommended to install it in the [python 3.7 + virtualenv]([etc/guide_virtualenv.md](https://fosslight.org/fosslight-guide-en/scanner/etc/guide_virtualenv.html)) environment.
 
 ```
 $ pip3 install fosslight_scanner

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ if __name__ == "__main__":
         download_url='https://github.com/fosslight/fosslight_scanner',
         classifiers=['License :: OSI Approved :: Apache Software License',
                      "Programming Language :: Python :: 3",
-                     "Programming Language :: Python :: 3.6",
                      "Programming Language :: Python :: 3.7",
                      "Programming Language :: Python :: 3.8",
                      "Programming Language :: Python :: 3.9", ],
+        python_requires=">=3.7",
         install_requires=required,
         package_data={'fosslight_scanner': ['resources/bom_compare.html']},
         entry_points={


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Change the minimum required version of Python to 3.7.

Reason :
- From ScanCode v31.0.1, Python 3.7+ is required.
  For this reason, the FOSSLight source scanner requires python 3.7.

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

