### PR TITLE
Optimize Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,25 @@
 # Copyright (c) 2022 LG Electronics Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM	ubuntu:20.04
+FROM python:3.8-slim-buster
 
-RUN 	apt-get update && apt-get install sudo -y
-RUN	ln -sf /bin/bash /bin/sh
-
-COPY	. /app
+COPY . /app
 WORKDIR	/app
 
-ENV 	DEBIAN_FRONTEND=noninteractive
+RUN	ln -sf /bin/bash /bin/sh && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y  \
+  build-essential \
+  python3 python3-distutils python3-pip python3-dev python3-magic \
+  libxml2-dev \
+  libxslt1-dev \
+  libhdf5-dev \
+  bzip2 xz-utils zlib1g libpopt0 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
-RUN	apt-get -y install build-essential
-RUN     apt-get -y install python3 python3-distutils python3-pip python3-dev
-RUN	apt-get -y install python3-intbitset python3-magic
-RUN	apt-get -y install libxml2-dev
-RUN	apt-get -y install libxslt1-dev
-RUN 	apt-get -y install libhdf5-dev
-RUN 	apt-get -y install bzip2 xz-utils zlib1g libpopt0 
-RUN	apt-get -y install gcc-10 g++-10
-RUN	pip3 install --upgrade pip
-RUN	pip3 install .
-RUN	pip3 install dparse
+RUN pip3 install --upgrade pip && \
+  pip3 install . && \
+  pip3 install dparse && \
+  rm -rf ~/.cache/pip /root/.cache/pipe
 
-ENTRYPOINT ["/usr/local/bin/fosslight"] 
+ENTRYPOINT ["/usr/local/bin/fosslight"]


### PR DESCRIPTION
## Description
related: #67 
I reduced the size of the docker image.
I'm trying to change base image to alpine or debian, but they increase size of image. Because this dockerfile uses python.
So I excluded it.

\<What I chaged\>
1. Changed base images from ubuntu to python:3.8-slim-buster
1. Many RUN methods were reduced using method chaining techniques
2. Clear caches 

This reduced the size from 1.66 Gb to 1.33 Gb and build time from 396.6s to 136.3s about 65% (on M1 Macbook Air, Ventura, 16GB, linux/amd64 build)
<img width="617" alt="image" src="https://github.com/fosslight/fosslight_scanner/assets/83010167/f1208278-bbfa-402c-949a-182f592fb607">

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

