### PR TITLE
Add simple_mode parameter to CoverItem constructor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ openpyxl
 progress
 pyyaml
 beautifulsoup4
-fosslight_util>=1.4.45
+fosslight_util>=1.4.48
 fosslight_source>=1.7.8
 fosslight_dependency>=3.15.1
 fosslight_binary>=4.1.30

--- a/src/fosslight_scanner/fosslight_scanner.py
+++ b/src/fosslight_scanner/fosslight_scanner.py
@@ -189,7 +189,8 @@ def run_scanner(src_path, dep_arguments, output_path, keep_raw_data=False,
         cover = CoverItem(tool_name=PKG_NAME,
                           start_time=_start_time,
                           input_path=abs_path,
-                          exclude_path=path_to_exclude)
+                          exclude_path=path_to_exclude,
+                          simple_mode=False)
         cover.comment = merge_cover_comment(_output_dir, merge_files)
 
         if output_extension == ".xlsx":


### PR DESCRIPTION
## Description
- Added the `simple_mode` parameter to include `FL source`, `dependency`, and `binary` in the FL Scanner output for a more comprehensive analysis.

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issue
- #102 

Before merging this PR, it is necessary to merge [this one](https://github.com/fosslight/fosslight_util/pull/173) first.