### PR TITLE
Change base image to fix docker build error on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 LG Electronics Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM python:3.8-slim-buster
+FROM --platform=linux/amd64 python:3.11
 
 COPY . /app
 WORKDIR	/app


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Change base image to fix docker build error on macOS.
- Docker build error message : 
``` 
134.3 Collecting scancode-toolkit==32.2.* (from ***_source<3.0.0,>=2.1.4->***-scanner==2.1.1)
....
134.4   Downloading scancode_toolkit-32.2.0-cp38-none-any.whl.metadata (16 kB)
134.9 ERROR: No matching distribution found for extractcode-7z>=16.5.210525; extra == "full"
```

## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

