### PR TITLE
Validate report sheets instead of relying on tox exit code

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov
 flake8
 pytest-flake8
 importlib-metadata
+openpyxl>=3.1.2

--- a/tests/test_fosslight_scanner.py
+++ b/tests/test_fosslight_scanner.py
@@ -1,5 +1,26 @@
+import openpyxl
+import pytest
 from fosslight_scanner.fosslight_scanner import run_scanner, download_source, init, run_main, run_dependency
 from fosslight_util.oss_item import ScannerItem
+from fosslight_util.constant import FOSSLIGHT_BINARY, FOSSLIGHT_DEPENDENCY, FOSSLIGHT_SOURCE, SHEET_NAME_FOR_SCANNER
+
+_SRC = SHEET_NAME_FOR_SCANNER[FOSSLIGHT_SOURCE]       # 'SRC_FL_Source'
+_BIN = SHEET_NAME_FOR_SCANNER[FOSSLIGHT_BINARY]       # 'BIN_FL_Binary'
+_DEP = SHEET_NAME_FOR_SCANNER[FOSSLIGHT_DEPENDENCY]   # 'DEP_FL_Dependency'
+
+SHEET_CHECK_PARAMS = [
+    pytest.param(["all"],        [_SRC, _BIN, _DEP], id="all"),
+    pytest.param(["source"],     [_SRC],             id="source"),
+    pytest.param(["binary"],     [_BIN],             id="binary"),
+    pytest.param(["dependency"], [_DEP],             id="dependency"),
+]
+
+
+def _get_sheet_names(xlsx_path: str) -> list:
+    wb = openpyxl.load_workbook(xlsx_path, read_only=True, data_only=True)
+    names = wb.sheetnames
+    wb.close()
+    return names
 
 
 def test_run_dependency(tmp_path):
@@ -148,3 +169,48 @@ def test_run_main(tmp_path):
 
     # then
     assert result is True
+
+
+@pytest.mark.parametrize("mode_list,expected_sheets", SHEET_CHECK_PARAMS)
+def test_output_excel_contains_required_sheets(tmp_path, mode_list, expected_sheets):
+    # given
+    src_path = tmp_path / "test_src"
+    output_dir = tmp_path / "output"
+    src_path.mkdir(parents=True, exist_ok=True)
+    (src_path / "hello.py").write_text("# test\nprint('hello')\n")
+
+    # when
+    result = run_main(
+        mode_list=mode_list,
+        path_arg=[str(src_path)],
+        dep_arguments=[],
+        output_file_or_dir=str(output_dir),
+        file_format=["excel"],
+        url_to_analyze="",
+        db_url="",
+        hide_progressbar=True,
+        keep_raw_data=False,
+        num_cores=1,
+        correct_mode=False,
+        correct_fpath="",
+        ui_mode=False,
+        path_to_exclude=[]
+    )
+
+    # then
+    assert result is True, "run_main should return True on success."
+
+    # Find the generated xlsx file
+    xlsx_files = list(output_dir.glob("*.xlsx"))
+    assert len(xlsx_files) == 1, (
+        f"Expected exactly one Excel report in {output_dir}, got {len(xlsx_files)}: {xlsx_files}"
+    )
+    xlsx_file = str(xlsx_files[0])
+
+    actual_sheets = _get_sheet_names(xlsx_file)
+    for sheet in expected_sheets:
+        assert sheet in actual_sheets, (
+            f"[mode={mode_list}] Sheet '{sheet}' not found. "
+            f"Actual sheets: {actual_sheets}. "
+            "One of the scanners may have failed silently."
+        )


### PR DESCRIPTION
## Description
Validate report sheets instead of relying on tox exit code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added openpyxl to development dependencies to support Excel report handling.

* **Tests**
  * Added tests that generate Excel reports and verify expected workbook sheets across scanner modes (all, source, binary, dependency).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fosslight/fosslight_scanner/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->