### PR TITLE
Remove 'vulnerability link' column from result report

### DIFF
--- a/src/fosslight_scanner/common.py
+++ b/src/fosslight_scanner/common.py
@@ -16,14 +16,6 @@ from fosslight_util.oss_item import OssItem, FileItem
 logger = logging.getLogger(LOGGER_NAME)
 SRC_SHEET = 'SRC_FL_Source'
 BIN_SHEET = 'BIN_FL_Binary'
-BIN_EXT_HEADER = {
-    'BIN_FL_Binary': [
-        'ID', 'Binary Path', 'OSS Name', 'OSS Version', 'License',
-        'Download Location', 'Homepage', 'Copyright Text', 'Exclude',
-        'Comment', 'Vulnerability Link', 'TLSH', 'SHA1'
-    ]
-}
-BIN_HIDDEN_HEADER = {'TLSH', 'SHA1'}
 
 
 def copy_file(source, destination):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated binary report output format: replaced "Vulnerability Link" column with "Comment" column in the BIN_FL_Binary sheet.
  * Fixed binary report headers to now properly include extended and hidden column headers in generated output files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->