### PR TITLE
Normalize report path separators to '/' on Windows

### DIFF
--- a/src/fosslight_scanner/common.py
+++ b/src/fosslight_scanner/common.py
@@ -119,16 +119,17 @@ def create_scancodejson(all_scan_item_origin, ui_mode_report, src_path=""):
         if src_path:
             fileitems_without_oss = []
             for root, _, files in os.walk(src_path):
-                root = root.replace(root_strip, "")
+                root = root.replace(root_strip, "").replace('\\', '/')
                 for file in files:
                     fi_without_oss = FileItem('')
                     included = False
-                    item_path = os.path.join(root, file)
-                    item_path = item_path.replace(parent + os.path.sep, '', 1)
+                    item_path = f"{root}/{file}".replace('\\', '/')
+                    item_path = item_path.replace(parent + '/', '', 1)
                     for file_items in all_scan_item.file_items.values():
                         for file_item in file_items:
                             if file_item.source_name_or_path:
-                                if file_item.source_name_or_path == item_path:
+                                existing_path = file_item.source_name_or_path.replace('\\', '/')
+                                if existing_path == item_path:
                                     included = True
                                     break
                     if not included:
@@ -140,7 +141,8 @@ def create_scancodejson(all_scan_item_origin, ui_mode_report, src_path=""):
             for file_items in all_scan_item.file_items.values():
                 for fi in file_items:
                     if fi.source_name_or_path:
-                        fi.source_name_or_path = os.path.join(root_dir, fi.source_name_or_path)
+                        normalized = fi.source_name_or_path.replace('\\', '/')
+                        fi.source_name_or_path = f"{root_dir}/{normalized}"
         write_scancodejson(os.path.dirname(ui_mode_report), os.path.basename(ui_mode_report),
                            all_scan_item)
     except Exception as ex:
@@ -167,7 +169,9 @@ def correct_scanner_result(all_scan_item):
                 for bin_fileitem in bin_fileitems:
                     if check_package_dir(bin_fileitem.source_name_or_path):
                         continue
-                    if src_fileitem.source_name_or_path == bin_fileitem.source_name_or_path:
+                    src_path_norm = src_fileitem.source_name_or_path.replace('\\', '/')
+                    bin_path_norm = bin_fileitem.source_name_or_path.replace('\\', '/')
+                    if src_path_norm == bin_path_norm:
                         dup_flag = True
                         src_all_licenses_non_empty = all(oss_item.license for oss_item in src_fileitem.oss_items)
                         bin_empty_license_exists = all(not oss_item.license for oss_item in bin_fileitem.oss_items)
@@ -200,9 +204,10 @@ def correct_scanner_result(all_scan_item):
 def check_package_dir(source_name_or_path):
     _package_dirs = ["venv", "node_modules", "Pods", "Carthage"]
     is_pkg = False
+    path_parts = source_name_or_path.replace('\\', '/').split('/')
 
     for package_dir in _package_dirs:
-        if package_dir in source_name_or_path.split(os.path.sep):
+        if package_dir in path_parts:
             is_pkg = True
             break
     return is_pkg

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,6 +6,7 @@
 
 import os
 import pytest
+from fosslight_util.constant import FOSSLIGHT_SOURCE, FOSSLIGHT_BINARY
 from fosslight_scanner.common import copy_file, run_analysis, call_analysis_api, check_package_dir, \
     create_scancodejson, correct_scanner_result
 
@@ -168,14 +169,14 @@ def test_correct_scanner_result(monkeypatch):
     bin_file_item = MockFileItem("path/to/source", [bin_oss_item])
 
     all_scan_item = MockAllScanItem({
-        "FOSSLIGHT_SOURCE": [src_file_item],
-        "FOSSLIGHT_BINARY": [bin_file_item]
+        FOSSLIGHT_SOURCE: [src_file_item],
+        FOSSLIGHT_BINARY: [bin_file_item]
     })
 
     # When
     result = correct_scanner_result(all_scan_item)
     # Then
-    assert len(result.file_items["FOSSLIGHT_BINARY"][0].oss_items) == 1
+    assert len(result.file_items[FOSSLIGHT_BINARY][0].oss_items) == 1
 
 
 @pytest.mark.parametrize("source_name_or_path, expected", [
@@ -185,8 +186,41 @@ def test_correct_scanner_result(monkeypatch):
     ("project/Carthage/file.swift", True),
     ("project/src/file.py", False),
     ("project/venv/file.py", True),
+    (r"project\venv\file.py", True),
+    (r"project\src\file.py", False),
 ])
 def test_check_package_dir(source_name_or_path, expected):
     result = check_package_dir(source_name_or_path)
     # Then
     assert result == expected
+
+
+def test_correct_scanner_result_matches_windows_separators():
+    class MockOSSItem:
+        def __init__(self, license, exclude=False):
+            self.license = license
+            self.exclude = exclude
+
+    class MockFileItem:
+        def __init__(self, source_name_or_path, oss_items, exclude=False):
+            self.source_name_or_path = source_name_or_path
+            self.oss_items = oss_items
+            self.exclude = exclude
+            self.comment = ""
+
+    class MockAllScanItem:
+        def __init__(self, file_items):
+            self.file_items = file_items
+
+    src_file_item = MockFileItem("path/to/source", [MockOSSItem(license="MIT")])
+    bin_file_item = MockFileItem(r"path\to\source", [MockOSSItem(license="")])
+
+    all_scan_item = MockAllScanItem({
+        FOSSLIGHT_SOURCE: [src_file_item],
+        FOSSLIGHT_BINARY: [bin_file_item]
+    })
+
+    result = correct_scanner_result(all_scan_item)
+    assert len(result.file_items[FOSSLIGHT_SOURCE]) == 0
+    assert result.file_items[FOSSLIGHT_BINARY][0].oss_items[0].license == "MIT"
+    assert result.file_items[FOSSLIGHT_BINARY][0].comment == 'Loaded from SRC OSS info'


### PR DESCRIPTION
Keep create_scancodejson and src/bin correction consistent across platforms so path matching does not fail on backslash separators.

